### PR TITLE
Modify method of building get repository

### DIFF
--- a/bin/rbenv-installer
+++ b/bin/rbenv-installer
@@ -60,12 +60,7 @@ else
     rbenv="$(brew --prefix)/bin/rbenv"
   else
     echo "Installing rbenv with git..."
-    mkdir -p ~/.rbenv
-    cd ~/.rbenv
-    git init
-    git remote add origin https://github.com/rbenv/rbenv.git
-    git fetch origin master
-    git checkout master
+    git clone https://github.com/rbenv/rbenv.git ~/.rbenv
     try_bash_extension
     rbenv=~/.rbenv/bin/rbenv
 


### PR DESCRIPTION
… by default.  Setups up remote also. 
Fixes "* branch            master     -> FETCH_HEAD
error: pathspec 'master' did not match any file(s) known to git."