### PR TITLE
Update rbenv-installer to ensure all tags  are pulled

### DIFF
--- a/bin/rbenv-installer
+++ b/bin/rbenv-installer
@@ -48,7 +48,7 @@ if [ -n "$rbenv" ]; then
     fi
   elif git remote -v 2>/dev/null | grep -q rbenv; then
     echo "Trying to update with git..."
-    git pull origin master
+    git pull --tags origin master
     cd ..
     try_bash_extension
   fi


### PR DESCRIPTION
See the ticket https://github.com/rbenv/rbenv/issues/861 about the problem. Without the flag `--tags` in line 51, the tags are not automatically pulled. 
