### PR TITLE
Use pull to support old version of git

### DIFF
--- a/bin/rbenv-installer
+++ b/bin/rbenv-installer
@@ -64,8 +64,8 @@ else
     cd ~/.rbenv
     git init
     git remote add origin https://github.com/rbenv/rbenv.git
-    git fetch origin master
-    git checkout master
+    git checkout -b master
+    git pull origin master
     try_bash_extension
     rbenv=~/.rbenv/bin/rbenv
 


### PR DESCRIPTION
I am using git version 1.8.3 on CentOS 7.2，having this error when execute rbenv-installer

```
error: pathspec 'master' did not match any file(s) known to git.
```

It seems old git doesn't get remote branch info when fetch specified remote banch.
