### PR TITLE
Suppress errors from 'which' during search for rbenv-installs.

### DIFF
--- a/bin/rbenv-doctor
+++ b/bin/rbenv-doctor
@@ -95,7 +95,7 @@ fi
 
 echo -n "Checking \`rbenv install' support: "
 rbenv_installs="$({ ls "$RBENV_ROOT"/plugins/*/bin/rbenv-install 2>/dev/null || true
-                    which -a rbenv-install || true
+                    which -a rbenv-install 2>/dev/null || true
                   } | uniq)"
 num_installs="$(wc -l <<<"$rbenv_installs")"
 if [ $num_installs -eq 0 ]; then


### PR DESCRIPTION
The execution of `which -a rbenv-install` in the check for 'rbenv install' support step of the rbenv-doctor script will output to stderr reporting that 'rbenv-install' can't be found when ruby-build is installed as an rbenv plugin. This is expected behaviour of the which command in this context of the script (when ruby-build is installed as an rbenv plugin) and can be safely suppressed in the same way that stderr from the `ls` command is suppressed in the line above it.

Example script output with unwanted stderr text from the `which` command:
```
[vagrant@localhost ~]$ curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | bash
Checking for `rbenv' in PATH: /home/vagrant/.rbenv/bin/rbenv
Checking for rbenv shims in PATH: OK
Checking `rbenv install' support: which: no rbenv-install in (/home/vagrant/.rbenv/shims:/home/vagrant/.rbenv/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/vagrant/.local/bin:/home/vagrant/bin)
/home/vagrant/.rbenv/plugins/ruby-build/bin/rbenv-install (ruby-build 20180224)
Counting installed Ruby versions: 1 versions
Checking RubyGems settings: OK
Auditing installed plugins: OK
```
The script output when stderr of the `which` command is suppressed:
```
[vagrant@localhost tmp1]$ bash rbenv-doctor
Checking for `rbenv' in PATH: /home/vagrant/.rbenv/bin/rbenv
Checking for rbenv shims in PATH: OK
Checking `rbenv install' support: /home/vagrant/.rbenv/plugins/ruby-build/bin/rbenv-install (ruby-build 20180224)
Counting installed Ruby versions: 1 versions
Checking RubyGems settings: OK
Auditing installed plugins: OK
```
