### PR TITLE
Fix rbenv-install it can successfully install rbenv.

### DIFF
--- a/bin/rbenv-installer
+++ b/bin/rbenv-installer
@@ -107,16 +107,23 @@ fi
 mkdir -p "${rbenv_root}/cache"
 
 echo
+echo "Temporarily adding \`~/.rbenv/bin' and \`~/.rbenv/shims' to PATH for doctor script..."
+export PATH=~/.rbenv/bin:~/.rbenv/shims:$PATH
+
+echo "Setting up rbenv in your shell..."
+rbenv init -
+
+echo
 echo "Running doctor script to verify installation..."
 http https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | "$BASH"
 
 echo
 echo "All done!"
-echo "Note that this installer doesn't yet configure your shell startup files:"
-i=0
-if [ -x ~/.rbenv/bin ]; then
-  echo "$((++i)). You'll want to ensure that \`~/.rbenv/bin' is added to PATH."
-fi
-echo "$((++i)). Run \`rbenv init' to see instructions how to configure rbenv for your shell."
-echo "$((++i)). Launch a new terminal window to verify that the configuration is correct."
+
+echo
+echo "Note that this installer doesn't yet configure your shell startup files."
+echo "You'll want to ensure that \`~/.rbenv/bin' and \`~/.rbenv/shims' are added to PATH:"
+echo "- For Bash: \`echo 'export PATH="\$HOME/.rbenv/bin:\$HOME/.rbenv/shims:\$PATH"' >> ~/.bashrc'"
+echo "- For Zsh: \`echo 'export PATH="\$HOME/.rbenv/bin:\$HOME/.rbenv/shims:\$PATH"' >> ~/.zshrc'"
+echo "Then launch a new terminal window to verify that the configuration is correct."
 echo


### PR DESCRIPTION
Before this commit, `rbenv-install` doesn't correctly install rbenv. It
fails the doctor script check because some variables are not configured
properly. This commit fixed that and also added precise instructions
about how to augment PATH.