### PR TITLE
Update README.md with my Ubuntu installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-install
 wget -q https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer -O- | bash
 ```
 
+Small caveat, for Ubuntu you are going to need to modify the PATH in your shell 
+startup before running the installer. You can do this by configuring your `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`, with something like:
+
+```
+export PATH=$HOME/.rbenv/bin:$PATH
+```
+
+
 ## rbenv-doctor
 
 After the installation, a separate `rbenv-doctor` script is run to verify the

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ startup before running the installer. You can do this by configuring your `~/.ba
 export PATH=$HOME/.rbenv/bin:$PATH
 ```
 
+Also, after installing add this to your shell startup:
+
+```
+eval "$(rbenv init -)"
+```
 
 ## rbenv-doctor
 


### PR DESCRIPTION
For Ubuntu installation with the $PATH correctly set it fails with:

```
Cloning into '/home/cruz3/.rbenv/plugins/ruby-build'...
remote: Counting objects: 8935, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 8935 (delta 3), reused 14 (delta 0), pack-reused 8918
Receiving objects: 100% (8935/8935), 1.88 MiB | 2.08 MiB/s, done.
Resolving deltas: 100% (5721/5721), done.

Running doctor script to verify installation...
Checking for `rbenv' in PATH: not found
  You seem to have rbenv installed in `/home/cruz3/.rbenv/bin', but that
  directory is not present in PATH. Please add it to PATH by configuring
  your `~/.bashrc', `~/.zshrc', or `~/.config/fish/config.fish'.
```