### PR TITLE
Recommend a more recent version of Ruby

### DIFF
--- a/bin/rbenv-doctor
+++ b/bin/rbenv-doctor
@@ -132,7 +132,7 @@ if [ $num_rubies -eq 0 ]; then
   echo "There aren't any Ruby versions installed under \`$RBENV_ROOT/versions'." | indent
   [ $num_installs -eq 0 ] || {
     echo -n "You can install Ruby versions like so: "
-    printc bright "rbenv install 2.2.4\n"
+    printc bright "rbenv install 2.6.3\n"
   } | indent
 else
   printc green "%d versions\n" $num_rubies


### PR DESCRIPTION
A small tweak to the documentation to recommend Ruby 2.6.3 instead of the very old (and no longer supported) 2.2.4.