### PR TITLE
Add option "-d" for not running doctor script

### DIFF
--- a/bin/rbenv-installer
+++ b/bin/rbenv-installer
@@ -105,9 +105,12 @@ fi
 # Enable caching of rbenv-install downloads
 mkdir -p "${rbenv_root}/cache"
 
-echo
-echo "Running doctor script to verify installation..."
-http https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | "$BASH"
+getopts ":d" NO_DOCTOR;
+if [[ $NO_DOCTOR != "d" ]]; then
+  echo
+  echo "Running doctor script to verify installation..."
+  http https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | "$BASH"
+fi
 
 echo
 echo "All done!"


### PR DESCRIPTION
installation is always verified by rbenv-doctor which will always trigger an error message: 
```
Checking for `rbenv' in PATH: which: no rbenv in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
not found
```
And then exit. In order to let the script finish the installation an extra option `-d` is added in order to skip the doctor script. Running doctor still a good idea when your are running it as an user, but not when you are trying to automate it.