### PR TITLE
Update warning to include instructions for Windows Subsystem for Linux (WSL)

### DIFF
--- a/bin/rbenv-doctor
+++ b/bin/rbenv-doctor
@@ -39,20 +39,17 @@ fi
 
 warnings=0
 
-if [ $(uname -s) = "Darwin" ]; then
-  bashrc=".bash_profile"
-else
-  bashrc=".bashrc"
-fi
 
 echo -n "Checking for \`rbenv' in PATH: "
 num_locations="$(which -a rbenv | uniq | wc -l)"
 if [ $num_locations -eq 0 ]; then
   printc red "not found\n"
   { if [ -x ~/.rbenv/bin/rbenv ]; then
-      echo "You seem to have rbenv installed in \`$HOME/.rbenv/bin', but that"
+      echo "You seem to have rbenv installed in the directory: \`$HOME/.rbenv/bin', but this"
       echo "directory is not present in PATH. Please add it to PATH by configuring"
-      echo "your \`~/${bashrc}', \`~/.zshrc', or \`~/.config/fish/config.fish'."
+      echo "your \`~/.bashrc', \`~/.bash_profile' \`~/.zshrc', or \`~/.config/fish/config.fish'"
+      echo "according to Sesion \`Basic GitHub Checkout' on the \`Readme'."
+      
     else
       echo "Please refer to https://github.com/rbenv/rbenv#installation"
     fi


### PR DESCRIPTION
Update warning to include instructions for Windows Subsystem for Linux (WSL) and remove Darwin conditon.
The condition never never reached a .bash_profile case, which is for configuring in WSL cases.
To avoid many conditional statments, I refer to Readme, session "Basic GitHub Checkout" where I have also modified in a pull request: #14
I wish you all the best! 