### PR TITLE
Copyable commands on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ install/upgrade`. Otherwise, rbenv is installed under `~/.rbenv`.
 Additionally, [ruby-build](https://github.com/rbenv/ruby-build#readme) is also
 installed if `rbenv install` is not already available.
 
-```sh
-# with curl
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+with curl:
 
-# alternatively, with wget
-wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
-```
+  ```sh
+  curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+  ```
+
+alternatively, with wget:
+
+  ```sh
+  wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
+  ```
 
 The installer script is meant for casual use on your own development machine.
 For automating installation across machines it's better to _avoid_ using this
@@ -28,10 +32,14 @@ you are installing rbenv there, you are likely doing something wrong.
 
 You can verify the state of your rbenv installation with:
 
-```sh
-# with curl
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor | bash
+with curl:
 
-# alternatively, with wget
-wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor -O- | bash
-```
+  ```sh
+  curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor | bash
+  ```
+
+alternatively, with wget:
+
+  ```sh
+  wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor -O- | bash
+  ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ alternatively, with wget:
   wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
   ```
 
+> **Note**
 The installer script is meant for casual use on your own development machine.
 For automating installation across machines it's better to _avoid_ using this
 script in favor of fine-tuning rbenv & ruby-build installation manually. Some


### PR DESCRIPTION
GitHub's markdown renderer makes code blocks copyable, but it's the
_entire_ codeblock that is copied. Since users would want to only run
one of the various commands, they need to each be their own codeblock
for the copy button to be useful.

sample: 
<img width="958" alt="image" src="https://user-images.githubusercontent.com/119972/221596757-92d71fcd-7432-43f7-b057-98209d511d28.png">
(note the copy button on hover now copies just a snippet that's runnable as-is)

I also block-quoted what _feels_ like a Note, thanks to github's new styling (they call out Note and Warning blockquotes with a bit more flourish)

<img width="965" alt="image" src="https://user-images.githubusercontent.com/119972/221598902-abc1ed47-d56c-4e06-8a67-facda6550953.png">
